### PR TITLE
chore(docs): remove irrelevant callout

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file list code owners for the repository, or part of it.
+# See https://help.github.com/articles/about-code-owners/
+
+
+*                                 Kosai106
+

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -6,12 +6,6 @@ Define the shape of your data using our schemas and modifiers, and match it agai
 
 ## Getting started
 
-import { Callout } from 'nextra/components'
-
-<Callout type="info" emoji="ℹ️">
-  ValidaThor is not yet published, so the following command will not work.
-</Callout>
-
 ```sh npm2yarn
 npm i @nordic-ui/validathor
 ```

--- a/apps/docs/theme.config.tsx
+++ b/apps/docs/theme.config.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { Callout, DocsThemeConfig, useConfig } from 'nextra-theme-docs'
+import { DocsThemeConfig, useConfig } from 'nextra-theme-docs'
 import React from 'react'
 
 const WordMark = () => <span className="logo-wordmark">Valida<span>Thor</span> <span className="emoji-fix">⚡️</span></span>
@@ -58,10 +58,6 @@ const config: DocsThemeConfig = {
 
     return (
       <>
-        <Callout type="info">
-          ValidaThor is still a work in progress and isn't yet published on NPM.
-        </Callout>
-
         {children}
       </>
     );

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "validathor-mono",
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
ValidaThor has been released on npm so this callout is no longer needed.

Also adds a `CODEOWNERS` file